### PR TITLE
Bump main.js cache-buster to ?75

### DIFF
--- a/templates/head.php
+++ b/templates/head.php
@@ -7,7 +7,7 @@
     <link rel="stylesheet" href="/bootstrap/css/bootstrap-responsive.min.css" type="text/css"/>
 
     <script src="/javascript/jquery-1.7.2.min.js" type="text/javascript"></script>
-    <script src="/javascript/main.js?74" type="text/javascript"></script>
+    <script src="/javascript/main.js?75" type="text/javascript"></script>
     <script src="/bootstrap/js/bootstrap.js" type="text/javascript"></script>
     <script src="/bootstrap/js/bootstrap-dropdown.js" type="text/javascript"></script>
 </head>


### PR DESCRIPTION
## What

Bumps the `main.js` version query in `templates/head.php` from `?74` to `?75`. One line.

## Why

#17 changed `main.js` but was squash-merged just before the follow-up commit carrying this bump landed on the branch, so it never reached `develop`. Without it, returning visitors keep the *cached pre-#17* script, `localizeMatchTimes()` doesn't exist in their browsers, and match times stay in server format on every tab — exactly the symptom observed on the live site after deploying #17.

## Reviewer notes

- CSS stays at `?74` — it didn't change (the repo bumps these counters per asset).
- Deploy after merging; visitors' browsers will then fetch `main.js?75` automatically, no hard refresh needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)